### PR TITLE
keep state for hooks between runs

### DIFF
--- a/pkg/agent/hook/hook.go
+++ b/pkg/agent/hook/hook.go
@@ -1,8 +1,10 @@
 package hook
 
 import (
+	"bytes"
 	"errors"
 	"os/exec"
+	"sync"
 
 	"github.com/cbroglie/mustache"
 )
@@ -16,25 +18,43 @@ const Start = "start"
 // Hook represents a configured hook
 type Hook struct {
 	cmdLine string
+	lock    sync.Mutex
+	state   []byte
 }
 
 // New creates a new hook with an unparsed command line. The line
 // will be
 func New(cmdLine string) *Hook {
-	return &Hook{cmdLine: cmdLine}
+	return &Hook{
+		cmdLine: cmdLine,
+		state:   []byte{},
+	}
 }
 
 // Run the hook. if an exit value other than 0 occurs, the combined
 // output will be returned in the error.
 func (h *Hook) Run(attrs interface{}) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
 	out, err := mustache.Render(h.cmdLine, attrs)
 	if err != nil {
 		return err
 	}
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
 	cmd := exec.Command("sh", "-c", out)
-	rs, err := cmd.CombinedOutput()
+	cmd.Stdin = bytes.NewReader(h.state)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
 	if err != nil {
-		return errors.New(string(rs))
+		return errors.New(string(stderr.Bytes()))
 	}
+	h.state = stdout.Bytes()
+
 	return nil
 }

--- a/pkg/agent/hook/hook_test.go
+++ b/pkg/agent/hook/hook_test.go
@@ -1,6 +1,7 @@
 package hook_test
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,4 +29,25 @@ func TestHook_Error(t *testing.T) {
 
 	err := h.Run(map[string]string{"path": "/tmp/TestHook_Explore"})
 	require.Error(t, err)
+}
+
+func TestHook_State(t *testing.T) {
+	os.Remove("/tmp/TestHook_State")
+	h := hook.New("wc -c | tee /tmp/TestHook_State")
+
+	// run the hook, passing empty array in as stdin, so 0 len
+	err := h.Run(map[string]string{})
+	require.NoError(t, err)
+	body, err := ioutil.ReadFile("/tmp/TestHook_State")
+	require.NoError(t, err)
+	// except 0 len recorded
+	require.Equal(t, "       0\n", string(body))
+
+	// state should now be "       0\n" so len should be 9
+	err = h.Run(map[string]string{})
+	require.NoError(t, err)
+	body, err = ioutil.ReadFile("/tmp/TestHook_State")
+	require.NoError(t, err)
+	// expect len 9 for the state, now that it exists :-)
+	require.Equal(t, "       9\n", string(body))
 }

--- a/pkg/agent/hook/hook_test.go
+++ b/pkg/agent/hook/hook_test.go
@@ -49,6 +49,6 @@ func TestHook_State(t *testing.T) {
 	require.NoError(t, err)
 	body, err = ioutil.ReadFile("/tmp/TestHook_State")
 	require.NoError(t, err)
-	// expect len 9 for the state, now that it exists :-)
-	require.Equal(t, "9", strings.TrimSpace(string(body)))
+	// expect len 1 or 9 (linux or osx), so "not 0" for the state, now that it exists :-)
+	require.NotEqual(t, "0", strings.TrimSpace(string(body)))
 }

--- a/pkg/agent/hook/hook_test.go
+++ b/pkg/agent/hook/hook_test.go
@@ -3,6 +3,7 @@ package hook_test
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/epithet-ssh/epithet/pkg/agent/hook"
@@ -41,7 +42,7 @@ func TestHook_State(t *testing.T) {
 	body, err := ioutil.ReadFile("/tmp/TestHook_State")
 	require.NoError(t, err)
 	// except 0 len recorded
-	require.Equal(t, "       0\n", string(body))
+	require.Equal(t, "0", strings.TrimSpace(string(body)))
 
 	// state should now be "       0\n" so len should be 9
 	err = h.Run(map[string]string{})
@@ -49,5 +50,5 @@ func TestHook_State(t *testing.T) {
 	body, err = ioutil.ReadFile("/tmp/TestHook_State")
 	require.NoError(t, err)
 	// expect len 9 for the state, now that it exists :-)
-	require.Equal(t, "       9\n", string(body))
+	require.Equal(t, "9", strings.TrimSpace(string(body)))
 }


### PR DESCRIPTION
Hooks sometimes need to keep state between runs. To support this the agent will now capture stdout from previous runs and pass it as stdin to the next run.

The first run of a hook has not values in stdin (just sends EOF)