### PR TITLE
Release Windows packages and 64bits only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /epithet-auth
 .vscode
 tmp
-
+*.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,18 +5,35 @@ builds:
   - id: epithet-agent
     binary: epithet-agent
     main: ./cmd/epithet-agent/
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
   - id: epithet-auth
     binary: epithet-auth
     main: ./cmd/epithet-auth/
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
   - id: epithet-ca
     binary: epithet-ca
     main: ./cmd/epithet-ca/
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
 archives:
 - replacements:
     darwin: Darwin
     linux: Linux
     windows: Windows
-    386: i386
     amd64: x86_64
 checksum:
   name_template: 'checksums.txt'

--- a/cmd/epithet-agent/epithet-agent.go
+++ b/cmd/epithet-agent/epithet-agent.go
@@ -83,9 +83,6 @@ func run(cc *cobra.Command, args []string) error {
 	case rs := <-sigs:
 		signal.Stop(sigs)
 		switch rs {
-		case os.Kill:
-			log.Info("KILL received")
-			syscall.Kill(syscall.Getpid(), syscall.SIGKILL)
 		default:
 			log.Info("INT received")
 			return nil


### PR DESCRIPTION
Release packages for linux, mac, and windows, on 64bit only.
Removed SIGKILL branch, it seems golang can't catch that signal. https://golang.org/pkg/os/signal/#hdr-Types_of_signals