### PR TITLE
feat: add epithet server command

### DIFF
--- a/cmd/epithet/ca.go
+++ b/cmd/epithet/ca.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
@@ -59,10 +58,5 @@ func (c *CACLI) Run(logger *slog.Logger, tlsCfg tlsconfig.Config) error {
 	r.Handle("/", caserver.New(caInstance, logger, nil, certLogger))
 
 	logger.Info("listening", "address", c.Listen)
-	err = http.ListenAndServe(c.Listen, r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return listenAndServe(c.Listen, r)
 }

--- a/cmd/epithet/listen.go
+++ b/cmd/epithet/listen.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// listenAndServe starts an HTTP server on the given address.
+// If addr starts with "unix://", it listens on a Unix domain socket.
+// Otherwise it delegates to http.ListenAndServe for TCP.
+func listenAndServe(addr string, handler http.Handler) error {
+	if path, ok := strings.CutPrefix(addr, "unix://"); ok {
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			return err
+		}
+		defer ln.Close()
+		return http.Serve(ln, handler)
+	}
+	return http.ListenAndServe(addr, handler)
+}

--- a/cmd/epithet/main.go
+++ b/cmd/epithet/main.go
@@ -33,6 +33,7 @@ var cli struct {
 	Match     MatchCLI          `cmd:"match" help:"Invoked during ssh invocation in a 'Match exec ...'"`
 	CA        CACLI             `cmd:"ca" help:"Run the epithet CA server"`
 	Policy    PolicyServerCLI   `cmd:"policy" help:"Run the policy server with OIDC-based authorization"`
+	Server    ServerCLI         `cmd:"server" help:"Run CA and policy as supervised subprocesses behind a single port"`
 	Auth      AuthCLI           `cmd:"auth" help:"Authentication commands (OIDC, SAML, etc.)"`
 	ConfigDoc kongcue.ConfigDoc `cmd:"" help:"Print the configuration file schema and docs"`
 }

--- a/cmd/epithet/policy.go
+++ b/cmd/epithet/policy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -193,7 +192,7 @@ func (c *PolicyServerCLI) Run(logger *slog.Logger, tlsCfg tlsconfig.Config, unif
 		"match_patterns", matchPatterns,
 		"dynamic_policy", policySource != "")
 
-	return http.ListenAndServe(c.Listen, r)
+	return listenAndServe(c.Listen, r)
 }
 
 // loadServerConfigFromCUE decodes the server configuration (static) from CUE config.

--- a/cmd/epithet/server.go
+++ b/cmd/epithet/server.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"cuelang.org/go/cue"
+	"github.com/epithet-ssh/epithet/pkg/tlsconfig"
+	"golang.org/x/crypto/ssh"
+)
+
+// ServerCLI defines the CLI flags for the combined server command.
+// It runs both the CA and policy server as subprocesses behind a
+// single reverse proxy, simplifying deployment to a single process.
+type ServerCLI struct {
+	Listen string `help:"Public address to listen on" short:"l" default:":8080"`
+}
+
+func (c *ServerCLI) Run(logger *slog.Logger, _ tlsconfig.Config, unifiedConfig cue.Value) error {
+	// Read CA key path from ca.key in config, falling back to default.
+	caKeyPath := "/etc/epithet/ca.key"
+	if v := unifiedConfig.LookupPath(cue.ParsePath("ca.key")); v.Exists() {
+		if err := v.Decode(&caKeyPath); err != nil {
+			return fmt.Errorf("failed to decode ca.key from config: %w", err)
+		}
+	}
+
+	// Read CA private key and derive the public key so the policy
+	// server doesn't need separate configuration for it.
+	privKeyBytes, err := os.ReadFile(caKeyPath)
+	if err != nil {
+		return fmt.Errorf("unable to load ca key from %s: %w", caKeyPath, err)
+	}
+	signer, err := ssh.ParsePrivateKey(privKeyBytes)
+	if err != nil {
+		return fmt.Errorf("unable to parse ca key: %w", err)
+	}
+	caPubkey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+	logger.Info("derived ca public key", "path", caKeyPath)
+
+	// Create temp directory for domain sockets.
+	tmpDir, err := os.MkdirTemp("", "epithet-server-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	policySock := filepath.Join(tmpDir, "policy.sock")
+	caSock := filepath.Join(tmpDir, "ca.sock")
+
+	// Set up signal-aware context for subprocess lifecycle.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Build global flags to pass through to subprocesses.
+	globalArgs := buildGlobalArgs()
+
+	// Start policy subprocess first — the CA depends on it.
+	policyArgs := append(globalArgs, "policy",
+		"--listen", "unix://"+policySock,
+		"--ca-pubkey", caPubkey,
+	)
+	policyCmd := exec.CommandContext(ctx, os.Args[0], policyArgs...)
+	policyCmd.Stdout = os.Stdout
+	policyCmd.Stderr = os.Stderr
+	if err := policyCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start policy subprocess: %w", err)
+	}
+	logger.Info("started policy subprocess", "pid", policyCmd.Process.Pid, "socket", policySock)
+
+	if err := waitForSocket(ctx, policySock, 10*time.Second); err != nil {
+		_ = policyCmd.Process.Kill()
+		return fmt.Errorf("policy subprocess failed to become ready: %w", err)
+	}
+	logger.Info("policy subprocess ready")
+
+	// Start CA subprocess.
+	caArgs := append(globalArgs, "ca",
+		"--listen", "unix://"+caSock,
+		"--policy", "unix://"+policySock,
+		"--key", caKeyPath,
+	)
+	caCmd := exec.CommandContext(ctx, os.Args[0], caArgs...)
+	caCmd.Stdout = os.Stdout
+	caCmd.Stderr = os.Stderr
+	if err := caCmd.Start(); err != nil {
+		_ = policyCmd.Process.Kill()
+		return fmt.Errorf("failed to start ca subprocess: %w", err)
+	}
+	logger.Info("started ca subprocess", "pid", caCmd.Process.Pid, "socket", caSock)
+
+	if err := waitForSocket(ctx, caSock, 10*time.Second); err != nil {
+		_ = caCmd.Process.Kill()
+		_ = policyCmd.Process.Kill()
+		return fmt.Errorf("ca subprocess failed to become ready: %w", err)
+	}
+	logger.Info("ca subprocess ready")
+
+	// Build reverse proxy mux. /d/* routes to policy, everything else to CA.
+	mux := http.NewServeMux()
+	mux.Handle("/d/", unixReverseProxy(policySock, logger))
+	mux.Handle("/", unixReverseProxy(caSock, logger))
+
+	logger.Info("listening", "address", c.Listen)
+	server := &http.Server{
+		Addr:    c.Listen,
+		Handler: mux,
+	}
+
+	// Run HTTP server in a goroutine so we can handle shutdown.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	// Wait for either context cancellation (signal) or server error.
+	select {
+	case <-ctx.Done():
+		logger.Info("shutting down")
+	case err := <-errCh:
+		cancel()
+		if err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("http server error: %w", err)
+		}
+	}
+
+	// Graceful shutdown: stop accepting connections, then stop subprocesses.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	_ = server.Shutdown(shutdownCtx)
+
+	// Stop CA first (stop accepting cert requests), then policy.
+	_ = caCmd.Process.Signal(syscall.SIGTERM)
+	_ = caCmd.Wait()
+	_ = policyCmd.Process.Signal(syscall.SIGTERM)
+	_ = policyCmd.Wait()
+
+	logger.Info("shutdown complete")
+	return nil
+}
+
+// buildGlobalArgs constructs the global CLI flags to pass through to subprocesses.
+func buildGlobalArgs() []string {
+	var args []string
+	if configFlag := strings.Join([]string(cli.Config), ";"); configFlag != "" {
+		args = append(args, "--config", configFlag)
+	}
+	for i := 0; i < cli.Verbose; i++ {
+		args = append(args, "-v")
+	}
+	if cli.Insecure {
+		args = append(args, "--insecure")
+	}
+	if cli.TLSCACert != "" {
+		args = append(args, "--tls-ca-cert", cli.TLSCACert)
+	}
+	if cli.LogFile != "" {
+		args = append(args, "--log-file", cli.LogFile)
+	}
+	return args
+}
+
+// unixReverseProxy creates an httputil.ReverseProxy that routes to a Unix domain socket.
+func unixReverseProxy(socketPath string, logger *slog.Logger) http.Handler {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+	}
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = "localhost"
+		},
+		Transport: transport,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			logger.Error("proxy error", "path", r.URL.Path, "error", err)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		},
+	}
+	return proxy
+}
+
+// waitForSocket polls until a Unix domain socket accepts connections or the context is cancelled.
+func waitForSocket(ctx context.Context, path string, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for socket %s", path)
+		case <-ticker.C:
+			conn, err := net.DialTimeout("unix", path, time.Second)
+			if err == nil {
+				conn.Close()
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/tlsconfig/tlsconfig.go
+++ b/pkg/tlsconfig/tlsconfig.go
@@ -66,7 +66,11 @@ func NewHTTPClientWithTimeout(cfg Config, timeout time.Duration) (*http.Client, 
 
 // ValidateURL checks if a URL is allowed given this TLS configuration.
 // Returns an error if the URL uses http:// without insecure mode enabled.
+// Unix socket URLs (unix://) are always allowed since they are local-only.
 func (c Config) ValidateURL(url string) error {
+	if strings.HasPrefix(url, "unix://") {
+		return nil
+	}
 	if strings.HasPrefix(url, "http://") && !c.Insecure {
 		return fmt.Errorf("URL %q uses insecure http:// protocol; use https:// or pass --insecure flag to allow insecure connections", url)
 	}

--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -1,0 +1,257 @@
+package server_test
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/epithet-ssh/epithet/pkg/sshcert"
+)
+
+// TestServerEndToEnd verifies the combined server command starts CA and policy
+// subprocesses and routes requests correctly through the reverse proxy.
+func TestServerEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Mock OIDC server — serves the two endpoints coreos/go-oidc needs
+	// for provider discovery: the openid-configuration and an empty JWKS.
+	var mockURL string
+	mockOIDC := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+				"issuer": %q,
+				"jwks_uri": %q,
+				"authorization_endpoint": %q,
+				"token_endpoint": %q,
+				"response_types_supported": ["code"]
+			}`, mockURL, mockURL+"/jwks", mockURL+"/auth", mockURL+"/token")
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"keys":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	mockURL = mockOIDC.URL
+	defer mockOIDC.Close()
+
+	// Build the epithet binary.
+	tmpDir := shortTempDir(t)
+	epithetBin := filepath.Join(tmpDir, "epithet")
+	buildCmd := exec.Command("go", "build", "-o", epithetBin, "../../cmd/epithet")
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build epithet: %v\n%s", err, output)
+	}
+
+	// Generate a CA key pair for the test.
+	caPubkey, caPrivkey, err := sshcert.GenerateKeys()
+	if err != nil {
+		t.Fatalf("failed to generate CA keys: %v", err)
+	}
+
+	caKeyPath := filepath.Join(tmpDir, "ca.key")
+	if err := os.WriteFile(caKeyPath, []byte(caPrivkey), 0600); err != nil {
+		t.Fatalf("failed to write CA key: %v", err)
+	}
+
+	// Write config YAML.
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := fmt.Sprintf(`ca:
+  key: %s
+  policy: "placeholder"
+policy:
+  ca_pubkey: "%s"
+  oidc:
+    issuer: "%s"
+    client_id: "test-client"
+  users:
+    test@example.com: [admin]
+  defaults:
+    allow:
+      root: [admin]
+    expiration: "5m"
+`, caKeyPath, strings.TrimSpace(string(caPubkey)), mockURL)
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// Find an available TCP port.
+	port := availablePort(t)
+
+	// Start the server. t.Context() cancels when the test ends,
+	// which ensures the process is killed if the test fails early.
+	serverCmd := exec.CommandContext(t.Context(), epithetBin,
+		"--config", configPath,
+		"server",
+		"--listen", fmt.Sprintf(":%d", port),
+		"-v",
+	)
+	serverCmd.Stdout = os.Stderr
+	serverCmd.Stderr = os.Stderr
+
+	if err := serverCmd.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+
+	// Wait for the server to accept TCP connections.
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForTCP(t, fmt.Sprintf("localhost:%d", port), 15*time.Second)
+
+	// Use a client that doesn't follow redirects so we can inspect 302 responses.
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// GET / → 200, body = CA public key (routed to CA subprocess).
+	t.Run("ca_pubkey", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/")
+		if err != nil {
+			t.Fatalf("GET / failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("GET / status = %d, want 200", resp.StatusCode)
+		}
+
+		body := make([]byte, 4096)
+		n, _ := resp.Body.Read(body)
+		got := strings.TrimSpace(string(body[:n]))
+		want := strings.TrimSpace(string(caPubkey))
+		if got != want {
+			t.Errorf("GET / body = %q, want %q", got, want)
+		}
+	})
+
+	// GET /d/current (no auth) → 302 with Location containing /d/.
+	t.Run("discovery_redirect_unauth", func(t *testing.T) {
+		resp, err := noRedirectClient.Get(baseURL + "/d/current")
+		if err != nil {
+			t.Fatalf("GET /d/current failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 302 {
+			t.Fatalf("GET /d/current status = %d, want 302", resp.StatusCode)
+		}
+
+		location := resp.Header.Get("Location")
+		if !strings.Contains(location, "/d/") {
+			t.Errorf("Location = %q, want it to contain /d/", location)
+		}
+	})
+
+	// GET /d/current with Authorization header → 302 with a different Location hash.
+	t.Run("discovery_redirect_auth", func(t *testing.T) {
+		// First get the unauthenticated redirect location.
+		unauthResp, err := noRedirectClient.Get(baseURL + "/d/current")
+		if err != nil {
+			t.Fatalf("unauth GET /d/current failed: %v", err)
+		}
+		unauthResp.Body.Close()
+		unauthLocation := unauthResp.Header.Get("Location")
+
+		// Now with an Authorization header.
+		req, _ := http.NewRequest("GET", baseURL+"/d/current", nil)
+		req.Header.Set("Authorization", "Bearer x")
+		authResp, err := noRedirectClient.Do(req)
+		if err != nil {
+			t.Fatalf("auth GET /d/current failed: %v", err)
+		}
+		authResp.Body.Close()
+
+		if authResp.StatusCode != 302 {
+			t.Fatalf("auth GET /d/current status = %d, want 302", authResp.StatusCode)
+		}
+
+		authLocation := authResp.Header.Get("Location")
+		if !strings.Contains(authLocation, "/d/") {
+			t.Errorf("auth Location = %q, want it to contain /d/", authLocation)
+		}
+		if authLocation == unauthLocation {
+			t.Errorf("auth and unauth redirects are the same (%s); expected different hashes", authLocation)
+		}
+	})
+
+	// Shutdown: send SIGTERM and wait for clean exit.
+	t.Run("clean_shutdown", func(t *testing.T) {
+		if err := serverCmd.Process.Signal(syscall.SIGTERM); err != nil {
+			t.Fatalf("failed to send SIGTERM: %v", err)
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- serverCmd.Wait()
+		}()
+
+		select {
+		case err := <-done:
+			// Process should exit cleanly (exit code 0 or signal termination).
+			if err != nil {
+				// On macOS/Linux, SIGTERM causes an exit error — that's fine.
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("server exited with: %v (status %d)", err, exitErr.ExitCode())
+				} else {
+					t.Errorf("unexpected wait error: %v", err)
+				}
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("server did not exit within 10s after SIGTERM")
+			serverCmd.Process.Kill()
+		}
+	})
+}
+
+// shortTempDir creates a temp directory with a short path to avoid
+// hitting the ~104 byte Unix socket path limit on macOS.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "es")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// availablePort returns an ephemeral TCP port that is currently available.
+func availablePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+// waitForTCP polls until a TCP address accepts connections.
+func waitForTCP(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to accept connections", addr)
+}


### PR DESCRIPTION
## Summary

- Adds `epithet server` command that runs CA and policy as supervised subprocesses behind a single reverse proxy on unix domain sockets
- Routes `/d/*` to the policy server and everything else to the CA, exposing both on a single port
- Supports graceful shutdown via SIGTERM/SIGINT with ordered subprocess teardown
- Adds integration test with a mock OIDC server verifying proxy routing, auth-aware discovery redirects, and clean shutdown

## Changes

- `cmd/epithet/server.go` — supervisor managing subprocess lifecycle, signal handling, and reverse proxy mux
- `cmd/epithet/listen.go` — shared `listenAndServe` helper supporting both TCP and `unix://` socket listeners
- `pkg/ca/ca.go` — support `unix://` policy URLs by configuring socket transport on the HTTP client
- `pkg/tlsconfig/tlsconfig.go` — allow `unix://` URLs without requiring `--insecure` flag
- `test/server/server_test.go` — end-to-end integration test with mock OIDC, no network dependencies

## Test plan

- [x] `go test -v ./test/server/` passes (mock OIDC, no network needed)
- [x] `go test ./...` — all existing tests still pass
- [ ] Manual: `epithet server --config <config> --listen :8080` starts and serves on single port

🤖 Generated with [Claude Code](https://claude.com/claude-code)